### PR TITLE
Remove export on global variable

### DIFF
--- a/src/Prism.svelte
+++ b/src/Prism.svelte
@@ -1,6 +1,6 @@
 <script context="module">
   import _prism from "./import";
-  export let global = {
+  let global = {
     transform: x => x
   };
   export const prism = _prism


### PR DESCRIPTION
If I start the Routify website, I get the following warning.

```
(!) Plugin svelte: Prism has unused export property 'global'. If it is for external reference only, please consider using `export const global`
node_modules/svelte-prism/src/Prism.svelte
1: <script context="module">
2:   import _prism from "./import";
3:   export let global = {
                ^
4:     transform: x => x
5:   };
```

So I removed the export here. Is that gonna break things? Unsure how to test this since it's an external module. 