### PR TITLE
Fix unwanted indents and spaces

### DIFF
--- a/src/Prism.svelte
+++ b/src/Prism.svelte
@@ -30,12 +30,4 @@
   <slot />
 </code>
 
-<pre class="language-{language}" command-line data-output="2-17">
-  <code class="language-{language}">
-    {#if language === 'none'}
-      {formattedCode}
-    {:else}
-      {@html formattedCode}
-    {/if}
-  </code>
-</pre>
+<pre class="language-{language}" command-line data-output="2-17"><code class="language-{language}">{#if language === 'none'}{formattedCode}{:else}{@html formattedCode}{/if}</code></pre>


### PR DESCRIPTION
Hey,
There's a problem with with the spaces and indentions in the component:  
Every space and indentation inside `<pre>` tag is visible everywhere we use the component (because it's a `<pre>` tag...)  

Here's an example and you can see the issue: https://svelte.dev/repl/e039b4a36387447d84d5aeb96113d677?version=3.46.4  
There a 3 new lines and many space characters coming right from `Prism.svelte` file  

I just inlined the content inside `<pre>` to fix this.