### PR TITLE
chore(exports): add exports to package.json for svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,11 @@
   "devDependencies": {
     "semantic-release": "^17.4.7",
     "svelte": "^3.47.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/Prism.d.ts",
+      "svelte": "./src/Prism.svelte"
+    }
   }
 }


### PR DESCRIPTION
This resolves the issue: 

> [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

svelte-prismjs@1.0.2